### PR TITLE
Ignore parser errors

### DIFF
--- a/resources/scripts/logs/npm.sh
+++ b/resources/scripts/logs/npm.sh
@@ -164,8 +164,8 @@ function npm(){
 
     echo -e "\nRUN NPM GOACCESS"
     if [[ "${DEBUG}" == "True" ]]; then
-        /goaccess-debug/goaccess --debug-file=${goaccess_debug_file} --invalid-requests=${goaccess_invalid_file} --no-global-config --config-file=${goan_config} &
+        /goaccess-debug/goaccess --num-tests=0 --debug-file=${goaccess_debug_file} --invalid-requests=${goaccess_invalid_file} --no-global-config --config-file=${goan_config} &
     else
-        /goaccess/goaccess --no-global-config --config-file=${goan_config} &
+        /goaccess/goaccess --num-tests=0 --no-global-config --config-file=${goan_config} &
     fi
 }


### PR DESCRIPTION
- fixes infinite loop in container with same error, which causes high CPU usage in dockerd because dump of huge amount of log in stdout
- fixes #156