### PR TITLE
Add ENABLE_BROWSERS_LIST & CUSTOM_BROWSERS env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ services:
             - BASIC_AUTH_PASSWORD=pass #optional   
             - EXCLUDE_IPS=127.0.0.1 #optional - comma delimited 
             - LOG_TYPE=NPM #optional - more information below
+            - ENABLE_BROWSERS_LIST=True #optional - more information below
+            - CUSTOM_BROWSERS=Kuma:Uptime,TestBrowser:Crawler #optional - comma delimited, more information below
         volumes:
         - /path/to/host/nginx/logs:/opt/log
         - /path/to/host/custom:/opt/custom #optional, required if using log_type = CUSTOM
@@ -82,6 +84,8 @@ services:
             - BASIC_AUTH_PASSWORD=pass #optional   
             - EXCLUDE_IPS=127.0.0.1 #optional - comma delimited 
             - LOG_TYPE=NPM #optional - more information below
+            - ENABLE_BROWSERS_LIST=True #optional - more information below
+            - CUSTOM_BROWSERS=Kuma:Uptime,TestBrowser:Crawler #optional - comma delimited, more information below
         volumes:
         - /path/to/host/nginx/logs:/opt/log
         - /path/to/host/custom:/opt/custom #optional, required if using log_type = CUSTOM
@@ -99,6 +103,8 @@ services:
 | `-e LOG_TYPE=`         |   (Optional) By default the configuration will be set to read NPM logs. Options are: CUSTOM, NPM, NPM+R, TRAEFIK, NCSA_COMBINED. More information below.|
 | `-e LOG_TYPE_FILE_PATTERN=`         |   (Optional) Only to be used with LOG_TYPE=NCSA_COMBINED or TRAEFIK. This parameter will pass along the file type you are trying match. For example you can pass -e LOG_TYPE_FILE_PATTERN="*.log" or -e LOG_TYPE_FILE_PATTERN="access.log". The default is *.log. Please keep it simple as I have not tested this completely. Use at your own RISK! |
 | `-e LANG=zh_CN.UTF-8 -e LANGUAGE=zh_CN.UTF-8`         |   (Optional) Language localization added. GoAccess only has a few translations available. Please visit https://github.com/allinurl/goaccess/tree/master/po to see the translations available. <br/><br/>**Current Translations**<br/>de - German<br/>es - Spanish<br/>fr - French<br/>it - Italian<br/>ja - Japanese<br/>ko - Korean<br/>pt_BR - Portuguese (Brazil)<br/>ru - Russian<br/>sv - Swedish<br/>uk - English (United Kingdom)<br/>zh_CN - Chinese - Simplified|
+| `-e ENABLE_BROWSERS_LIST=True/False`         |   (Optional) Defaults to False. Set to true if you would like to enable the [goaccess browsers.list](https://github.com/allinurl/goaccess/blob/master/config/browsers.list) file.     |
+| `-e CUSTOM_BROWSERS=`         |   - (Optional) Consumes the list of provided custom browsers. This is a comma separated list containing the custom browser(s) in the format `Browser:Browser_category`.<br/>- If your custom browser is already defined in the default `browsers.list` file, it will not be added. However, the `Browser_category` can be reused.<br/><br/> CUSTOM_BROWSERS list example: `Kuma:Crawlers,TestBrowser:Crawlers,Kuma:Uptime,Discordbot:Crawlers`<br/><br/>For the example above, only `Kuma:Crawlers` and `TestBrowser:Crawlers` will be appended to the `browsers.list` file. <br/><br/>`Kuma:Uptime` is ignored as the browser `Kuma` has already been defined in `Kuma:Crawlers`. `Discordbot:Crawlers` is ignored as the browser `Discordbot` is already defined in the [default browsers.list file](https://github.com/allinurl/goaccess/blob/master/config/browsers.list)<br/><br/>Note for users using CUSTOM LOG_TYPE:<br/><br/>If your `goaccess.conf` file references a browsers.list file other than the one located in the `/goaccess-config/ directory`, the CUSTOM_BROWSERS variable will be ignored.    |
 
 
 # **Additional environment information**  

--- a/resources/scripts/logs/custom.sh
+++ b/resources/scripts/logs/custom.sh
@@ -29,6 +29,15 @@ function custom_init(){
         fi
         if [[ -r ${goan_config} ]]; then
             echo -e "goaccess.conf readable"
+            if [[ "${ENABLE_BROWSERS_LIST}" == "True" || ${ENABLE_BROWSERS_LIST} == true ]]; then
+                if grep -Fwq "browsers-file" ${goan_config}; then
+                    echo -e "\n\t\BROWSERS FILE ALREADY DEFINED IN CUSTOM GOACCESS.CONF. IGNORING CUSTOM_BROWSERS VARIABLE"
+                else
+                    echo -e "\n\tENABLING CUSTOM INSTANCE GOACCESS BROWSERS LIST"
+                    browsers_file="/goaccess-config/browsers.list"
+                    echo "browsers-file ${browsers_file}" >> ${goan_config}
+                fi
+            fi
         else
             echo -e "goaccess.conf not readable"
             #exit

--- a/resources/scripts/logs/ncsa_combined.sh
+++ b/resources/scripts/logs/ncsa_combined.sh
@@ -21,7 +21,7 @@ function ncsa_combined_init(){
     if [[ -f ${html_config} ]]; then
         rm ${html_config}
     fi
-    
+
     echo -n "" > ${archive_log}
     echo -n "" > ${active_log}
 }
@@ -36,9 +36,14 @@ function ncsa_combined_goaccess_config(){
     echo "date-format %d/%b/%Y" >> ${goan_config}
     #echo "log-format [%d:%t %^] %^ %s %^ %^ %m %^ %v \"%U\" [%^ %h] [%^ %b] %^\"%u\" \"%R\"" >> ${goan_config}
     echo "log-format %h %^[%d:%t %^] \"%r\" %s %b \"%R\" \"%u\"" >> ${goan_config}
-    echo "port 7890" >> ${goan_config}    
+    echo "port 7890" >> ${goan_config}
     echo "real-time-html true" >> ${goan_config}
     echo "output ${nginx_html}" >> ${goan_config}
+    if [[ "${ENABLE_BROWSERS_LIST}" == "True" || ${ENABLE_BROWSERS_LIST} == true ]]; then
+        echo -e "\n\tENABLING NCSA_COMBINED INSTANCE GOACCESS BROWSERS LIST"
+        browsers_file="/goaccess-config/browsers.list"
+        echo "browsers-file ${browsers_file}" >> ${goan_config}
+    fi
 }
 
 function ncsa_combined(){
@@ -58,7 +63,7 @@ function ncsa_combined(){
 
     echo -e "\n#GOAN_NCSA_COMBINED_LOG_FILES" >> ${goan_config}
     if [[ -d "${goan_log_path}" ]]; then
-        
+
         echo -e "\n\tAdding proxy logs..."
         IFS=$'\n'
 
@@ -106,7 +111,7 @@ function ncsa_combined(){
     echo -e "\nSKIP ARCHIVED LOGS"
     echo "-------------------------------"
     echo "FEATURE NOT AVAILABLE FOR NCSA_COMBINED"
-    
+
     #write out loading page
     echo "<!doctype html><html><head>" > ${nginx_html}
     echo "<title>GOAN - ${goan_version}</title>" >> ${nginx_html}

--- a/resources/scripts/logs/npm.sh
+++ b/resources/scripts/logs/npm.sh
@@ -38,6 +38,11 @@ function npm_goaccess_config(){
     echo "port 7890" >> ${goan_config}
     echo "real-time-html true" >> ${goan_config}
     echo "output ${nginx_html}" >> ${goan_config}
+    if [[ "${ENABLE_BROWSERS_LIST}" == "True" || ${ENABLE_BROWSERS_LIST} == true ]]; then
+        echo -e "\n\tENABLING NPM INSTANCE GOACCESS BROWSERS LIST"
+        browsers_file="/goaccess-config/browsers.list"
+        echo "browsers-file ${browsers_file}" >> ${goan_config}
+    fi
 }
 
 function npm(){
@@ -57,7 +62,7 @@ function npm(){
 
     echo -e "\n#GOAN_NPM_PROXY_FILES" >> ${goan_config}
     if [[ -d "${goan_log_path}" ]]; then
-        
+
         echo -e "\n\tAdding proxy logs..."
         IFS=$'\n'
         for file in $(find "${goan_log_path}" -name 'proxy*host-*_access.log' ! -name "*_error.log");
@@ -100,7 +105,7 @@ function npm(){
             goan_archive_detail_log_count=0
 
             if [ $goan_archive_log_count != 0 ]
-            then 
+            then
                 echo -e "\n\tAdding proxy archive logs..."
 
                 IFS=$'\n'
@@ -138,7 +143,7 @@ function npm(){
                 unset IFS
 
                 echo -e "\n\tAdded (${goan_archive_detail_log_count}) proxy archived logs from ${goan_log_path}..."
-                
+
             else
                 echo -e "\n\tNo archived logs found at ${goan_log_path}..."
             fi

--- a/resources/scripts/logs/npm_error.sh
+++ b/resources/scripts/logs/npm_error.sh
@@ -38,6 +38,11 @@ function npm_error_goaccess_config(){
     echo "port 7892" >> ${goan_config}
     echo "real-time-html true" >> ${goan_config}
     echo "output ${nginx_html}" >> ${goan_config}
+    if [[ "${ENABLE_BROWSERS_LIST}" == "True" || ${ENABLE_BROWSERS_LIST} == true ]]; then
+        echo -e "\n\tENABLING NPM ERROR INSTANCE GOACCESS BROWSERS LIST"
+        browsers_file="/goaccess-config/browsers.list"
+        echo "browsers-file ${browsers_file}" >> ${goan_config}
+    fi
 }
 
 function npm_error(){
@@ -57,7 +62,7 @@ function npm_error(){
 
     echo -e "\n#GOAN_NPM_ERROR_FILES" >> ${goan_config}
     if [[ -d "${goan_log_path}" ]]; then
-        
+
         echo -e "\n\tAdding error logs..."
         IFS=$'\n'
         for file in $(find "${goan_log_path}" -name '*_error.log');
@@ -68,7 +73,7 @@ function npm_error(){
                 then
                     number_of_lines=`wc -l < $file`
                     how_many_lines_contain_warn=`grep -c "\[warn\]" $file`
-                    
+
                     if [ $how_many_lines_contain_warn == $number_of_lines ] && [ $number_of_lines != 0 ]
                     then
                         echo -e "\t${file} has inconsistent log types, skipping"
@@ -101,7 +106,7 @@ function npm_error(){
             goan_archive_log_count=`ls -1 ${goan_log_path}/*_error.log*.gz 2> /dev/null | wc -l`
 
             if [ $goan_archive_log_count != 0 ]
-            then 
+            then
                 echo -e "\n\tAdding error archive logs..."
 
                 IFS=$'\n'

--- a/resources/scripts/logs/npm_redirection.sh
+++ b/resources/scripts/logs/npm_redirection.sh
@@ -38,6 +38,11 @@ function npm_redirect_goaccess_config(){
     echo "port 7891" >> ${goan_config}
     echo "real-time-html true" >> ${goan_config}
     echo "output ${nginx_html}" >> ${goan_config}
+    if [[ "${ENABLE_BROWSERS_LIST}" == "True" || ${ENABLE_BROWSERS_LIST} == true ]]; then
+        echo -e "\n\tENABLING NPM REDIRECTION INSTANCE GOACCESS BROWSERS LIST"
+        browsers_file="/goaccess-config/browsers.list"
+        echo "browsers-file ${browsers_file}" >> ${goan_config}
+    fi
 }
 
 function npm_redirect(){
@@ -57,7 +62,7 @@ function npm_redirect(){
 
     echo -e "\n#GOAN_NPM_REDIRECT_FALLBACK_DEAD_FILES" >> ${goan_config}
     if [[ -d "${goan_log_path}" ]]; then
-        
+
         echo -e "\n\tAdding redirection/fallback/dead logs..."
         IFS=$'\n'
         for file in $(find "${goan_log_path}" \( -name 'redirection*host-*.log' -o -name 'fallback_access.log' -o -name 'dead-host*.log' \) ! -name "*_error.log*");
@@ -81,9 +86,9 @@ function npm_redirect(){
             echo -e "\tFALSE"
             goan_archive_log_count=$(find "${goan_log_path}" -type f \( -name 'redirection*host-*.log*.gz' -o -name 'fallback_access.log*.gz' -o -name 'dead-host*.log*.gz' \) ! -name "*_error.log*" | wc -l)
             goan_archive_detail_log_count=0
-            
+
             if [ $goan_archive_log_count != 0 ]
-            then 
+            then
                 echo -e "\n\tAdding redirection/fallback/dead archive logs..."
 
                 IFS=$'\n'
@@ -98,7 +103,7 @@ function npm_redirect(){
                 unset IFS
 
                 echo -e "\n\tAdded (${goan_archive_detail_log_count}) redirection/fallback/dead archived logs from ${goan_log_path}..."
-                
+
             else
                 echo -e "\tNo redirection/fallback archived logs found at ${goan_log_path}..."
             fi

--- a/resources/scripts/logs/traefik.sh
+++ b/resources/scripts/logs/traefik.sh
@@ -21,7 +21,7 @@ function traefik_init(){
     if [[ -f ${html_config} ]]; then
         rm ${html_config}
     fi
-    
+
     echo -n "" > ${archive_log}
     echo -n "" > ${active_log}
 }
@@ -35,9 +35,14 @@ function traefik_goaccess_config(){
     echo "time-format %T" >> ${goan_config}
     echo "date-format %d/%b/%Y" >> ${goan_config}
     echo "log-format %h %^[%d:%t %^] \"%r\" %s %b \"%R\" \"%u\" %Lm" >> ${goan_config}
-    echo "port 7890" >> ${goan_config}    
+    echo "port 7890" >> ${goan_config}
     echo "real-time-html true" >> ${goan_config}
     echo "output ${nginx_html}" >> ${goan_config}
+    if [[ "${ENABLE_BROWSERS_LIST}" == "True" || ${ENABLE_BROWSERS_LIST} == true ]]; then
+        echo -e "\n\tENABLING TRAEFIK INSTANCE GOACCESS BROWSERS LIST"
+        browsers_file="/goaccess-config/browsers.list"
+        echo "browsers-file ${browsers_file}" >> ${goan_config}
+    fi
 }
 
 function traefik(){
@@ -57,7 +62,7 @@ function traefik(){
 
     echo -e "\n#GOAN_PROXY_FILES" >> ${goan_config}
     if [[ -d "${goan_log_path}" ]]; then
-        
+
         echo -e "\n\tAdding proxy logs..."
         IFS=$'\n'
 
@@ -107,7 +112,7 @@ function traefik(){
     echo -e "\nSKIP ARCHIVED LOGS"
     echo "-------------------------------"
     echo "FEATURE NOT AVAILABLE FOR TRAEFIK"
-    
+
     #write out loading page
     echo "<!doctype html><html><head>" > ${nginx_html}
     echo "<title>GOAN - ${goan_version}</title>" >> ${nginx_html}

--- a/resources/scripts/start.sh
+++ b/resources/scripts/start.sh
@@ -28,6 +28,39 @@ fi
 tini -s -- nginx
 ### NGINX
 
+### COPY ORIGINAL BROWSERS LIST
+original_browsers_list=/goaccess/config/browsers.list
+browsers_list="/goaccess-config/browsers.list"
+if [[ -f ${browsers_list} ]]; then
+    rm ${browsers_list}
+    cp ${original_browsers_list} ${browsers_list}
+else
+    cp ${original_browsers_list} ${browsers_list}
+fi
+### END COPYING BROWSERS LIST
+
+### MODIFY BROWSERS LIST WITH USER'S CUSTOM BROWSERS
+if [ ! -z "${CUSTOM_BROWSERS}" ]; then
+    IFS=','
+    read -ra BROWSER_CATEGORY <<< "$CUSTOM_BROWSERS"
+    unset IFS
+    for b_c in "${BROWSER_CATEGORY[@]}"; do
+        IFS=':'
+        read -ra BROWSER <<< "$b_c"
+        if grep -Fwq "${BROWSER[0]}" ${browsers_list}
+        then
+            echo -e "\n\t${BROWSER[0]} ALREADY IN BROWSERS LIST"
+        else
+            echo -e "${BROWSER[0]}\t${BROWSER[1]}" >> ${browsers_list}
+            echo -e "\n\t${BROWSER[0]} ADDED TO BROWSERS LIST"
+        fi
+    done
+    unset IFS
+else
+    echo -e "\n\tCUSTOM_BROWSERS VARIABLE IS EMPTY"
+fi
+### END MODIFYING BROWSERS LIST
+
 # BEGIN PROXY LOGS
 if [[ -z "${LOG_TYPE}" || "${LOG_TYPE}" == "NPM" || "${LOG_TYPE}" == "NPM+R"  || "${LOG_TYPE}" == "NPM+ALL" ]]; then
     echo -e "\n\nNPM INSTANCE SETTING UP..."


### PR DESCRIPTION
# Changes

- Added optional `ENABLE_BROWSERS_LIST` and `CUSTOM_BROWSERS` variables.

### `start.sh` script changes

- When the container is started, the original goaccess `browsers.list` (located in `/goaccess/config/`) is copied to the `/goaccess-config` directory. If the user defined the `CUSTOM_BROWSERS` variable with a comma delimited list consisting of `Browser:Browser_category` items, these are appended to the `/goaccess-config/browsers.list` file.
- By checking if `browsers.list` is already present in the `/goaccess-config` directory at container runtime and subsequently removing it prior to copying over a fresh copy from the `/goaccess/config` directory, we can ensure that the `browsers.list` always aligns with the user's `CUSTOM_BROWSERS` variable. Since the `/goaccess/config/browsers.list` file is persistent, appending to it would result in custom browsers being left behind within the file when a user removes browser(s) from the `CUSTOM_BROWSERS` variable during a container restart - copying over a fresh file prior to appending custom browsers gets around this potential issue.
- For user defined `CUSTOM_BROWSERS`, if a Browser has already been defined in `browsers.list`, it will be ignored and not appended to the list. Only the browser category (e.g., Crawlers) can be the same for multiple custom browser definitions.

### `custom.sh`, `ncsa_combined.sh`, `npm.sh`, `npm_error.sh`, `npm_redirection.sh`, `traefik.sh` script changes

- If the `ENABLE_BROWSERS_LIST` variable is set to True, for each log type the corresponding `goaccess.conf` file has the line `browsers-file /goaccess-config/browsers.list` appended to it enabling the use of the `browsers.list` file.
- If a user didn't define the `CUSTOM_BROWSERS` variable, this will still allow them to use the default goaccess browsers list.
`Note regarding Custom Log Types`: Since a user may already have a `browser.list` file defined in their `goaccess.conf` file, if that is the case, their choice is respected instead of forcing them to use the file located at `/goaccess-config/browsers.list`. However, if they don't, but did enable the browsers list via the variable, then `/goaccess-config/browsers.list` is used and their custom browsers (if any defined) are appended to said file.


### Documentation

- I went ahead and added documentation related to these two new variables to the README
