### PR TITLE
Respect user specified LOG_TYPE_FILE_PATTERN for traefik

### DIFF
--- a/resources/scripts/logs/traefik.sh
+++ b/resources/scripts/logs/traefik.sh
@@ -69,8 +69,6 @@ function traefik(){
 
         if [[ -z "${LOG_TYPE_FILE_PATTERN}" ]]; then
             LOG_TYPE_FILE_PATTERN="access.log"
-        else
-            LOG_TYPE_FILE_PATTERN="*.log"
         fi
 
         for file in $(find "${goan_log_path}" -name "${LOG_TYPE_FILE_PATTERN}");


### PR DESCRIPTION
Previously was clobbered by "*.log" if user specified LOG_TYPE_FILE_PATTERN was given

Fixes #205 