### PR TITLE
Set read-only flag for log volumes in docker-compose.yml documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ services:
             - KEEP_LAST=30 #optional - Keep the last specified number of days in storage. https://goaccess.io/man
             - PROCESSING_THREADS=1 #optional - This parameter sets the number of concurrent processing threads in the program's execution, affecting log data analysis, typically adjusted based on CPU cores. Default is 1. https://goaccess.io/man
         volumes:
-        - /path/to/host/nginx/logs:/opt/log
-        - /path/to/host/custom:/opt/custom #optional, required if using log_type = CUSTOM
+        - /path/to/host/nginx/logs:/opt/log:ro
+        - /path/to/host/custom:/opt/custom:ro #optional, required if using log_type = CUSTOM
 ```
 If you have permission issues, you can add PUID and PGID with the correct user id that has read access to the log files.
 ```yml
@@ -101,8 +101,8 @@ services:
             - KEEP_LAST=30 #optional - Keep the last specified number of days in storage. https://goaccess.io/man
             - PROCESSING_THREADS=1 #optional - This parameter sets the number of concurrent processing threads in the program's execution, affecting log data analysis, typically adjusted based on CPU cores. Default is 1. https://goaccess.io/man
         volumes:
-        - /path/to/host/nginx/logs:/opt/log
-        - /path/to/host/custom:/opt/custom #optional, required if using log_type = CUSTOM
+        - /path/to/host/nginx/logs:/opt/log:ro
+        - /path/to/host/custom:/opt/custom:ro #optional, required if using log_type = CUSTOM
 ```
 
 | Parameter | Function |


### PR DESCRIPTION
This PR updates the docker-compose.yml examples in the documentation to mount log volumes as read-only (`:ro` flag). This prevents the container from accidentally modifying the host's log files, which is a security best practice since GoAccess only needs read access to analyze logs.
It's a very little thing but I feel like it's a good idea.
Thanks for your time !